### PR TITLE
Changing output of `predictCount()` to response scale.

### DIFF
--- a/src/R/predictCount.R
+++ b/src/R/predictCount.R
@@ -42,16 +42,16 @@ predictCount = function(object, newdata, cilevel = 0.95, digit = 3, print.out = 
     percent = 1 - (1 - cilevel)/2
     Conf.lower = pred$fit - qnorm(percent) * pred$se.fit
     Conf.upper = pred$fit + qnorm(percent) * pred$se.fit
-    mat = cbind(Predicted, Conf.lower, Conf.upper)
+    mat = exp(cbind(Predicted, Conf.lower, Conf.upper))
     mat = round(mat, digit)
     mat.df = as.data.frame(mat)
     dimnames(mat.df)[[1]] = dimnames(newdata)[[1]]
     dimnames(mat.df)[[2]] = c("Predicted", " Conf.lower", "Conf.upper")
     
-    if (print.out) 
+    if (print.out){
         print(mat.df)
-    
-    mat.df
+    }
+    invisible(mat.df)
     # invisible(list(frame = mat.df, fit = pred$fit, se.fit = pred$se.fit, df = pred$df, cilevel = cilevel))
 }
 


### PR DESCRIPTION
Bug fix: the `predictCount()` function was returning the values on the scale of the linear predictor (i.e., log(mu)), rather than the response scale. This is at odds with what appears in the STATS 20x notes.