### PR TITLE
Fixed labels in cooks20x() and modcheck()

### DIFF
--- a/src/R/cooks20x.R
+++ b/src/R/cooks20x.R
@@ -26,7 +26,7 @@
 #' 
 #' @export cooks20x
 cooks20x = function(x, main = "Cook's Distance plot", xlab = "observation number", ylab = "Cook's distance", 
-                    line = c(0.5, 0.1, 2), cex.labels = 1, axisOpts = list(xAxis = TRUE, yAxisTight = FALSE), ...) {
+                    line = c(0.5, 1.2, 2), cex.labels = 1, axisOpts = list(xAxis = TRUE, yAxisTight = FALSE), ...) {
   
     y = cooks.distance(x)
     show.r = order(-y)[1:3]

--- a/src/R/modcheck.R
+++ b/src/R/modcheck.R
@@ -81,6 +81,7 @@ modcheck.lm = function(x, plotOrder = 1:4,
   for(p in plotOrder){
     if(p == 1){
       args$eovcheck$axes = FALSE
+      args$eovcheck$ylab = ""
       args$eovcheck$x = formula(x$call$formula)
       args$eovcheck$data = data.frame(eval(x$call$data, parent.frame())) #x$model
       do.call(what = eovcheck, args = args$eovcheck)


### PR DESCRIPTION
cooks20x() - xlab = "Observation number" don't overlap with tickmark labels anymore.
modcheck() - ylab = "Residuals" do not appear twice in the eovcheck() plot in this.