### PR TITLE
Modification to make backtransformations easier

### DIFF
--- a/src/R/estimateContrasts.R
+++ b/src/R/estimateContrasts.R
@@ -14,6 +14,8 @@
 #' @param alpha the nominal error rate for the multiple confidence intervals.
 #' @param L number of contrasts. If NULL, L will be set to the number of rows
 #' in the contrast matrix, otherwise L will be as specified.
+#' @param FUN optional function to be applied to estimates and confidence intervals.
+#' Typically for backtransformation operations.
 #' @return Returns a matrix whose rows correspond to the different contrasts
 #' being estimated and whose columns correspond to the point estimate of the
 #' contrast, the Tukey lower and upper limits of the confidence interval, the
@@ -30,15 +32,17 @@
 #' contrast.matrix = matrix(c(-1/2, -1/2, 1), byrow = TRUE, nrow = 1, ncol = 3)
 #' contrast.matrix
 #' s20x:::estimateContrasts(contrast.matrix,computer.fit)
-estimateContrasts = function(contrast.matrix, fit, row = TRUE, alpha = 0.05, L = NULL) {
+estimateContrasts = function(contrast.matrix, fit, row = TRUE, alpha = 0.05, L = NULL, FUN = identity) {
+    FUN <- match.fun(FUN)
+
     if (!inherits(fit, "lm")) {
         stop("Second input is not an \"lm\" object")
     }
     
     if (length(dimnames(fit$model)[[2]]) == 2) {
-        estimateContrasts1(contrast.matrix, fit, alpha = alpha, L)
+        estimateContrasts1(contrast.matrix, fit, alpha = alpha, L, FUN = FUN)
     } else {
-        estimateContrasts2(contrast.matrix, fit, alpha = alpha, row, L)
+        estimateContrasts2(contrast.matrix, fit, alpha = alpha, row, L, FUN = FUN)
     }
 }
 

--- a/src/R/estimateContrasts1.R
+++ b/src/R/estimateContrasts1.R
@@ -1,4 +1,4 @@
-estimateContrasts1 = function(contrast.matrix, fit, alpha = 0.05, L) {
+estimateContrasts1 = function(contrast.matrix, fit, alpha = 0.05, L, FUN) {
     if (!inherits(fit, "lm")) 
         stop("Second input is not an \"lm\" object")
     if (length(dimnames(fit$model)[[2]]) != 2) 
@@ -29,7 +29,7 @@ estimateContrasts1 = function(contrast.matrix, fit, alpha = 0.05, L) {
     tukey.p = 1 - round((ptukey(abs(tstat) * sqrt(2), ncol(contrast.matrix), fit$df)), 4)
     bonf.p = pmin(round(L * 2 * (1 - pt(abs(tstat), fit$df)), 4), 1)
     # drop unadjusted probs 2005 outmat = cbind(contrasts, tl, tu, tukey.p, unadj.p)
-    outmat = cbind(contrasts, tl, tu, tukey.p)
+    outmat = cbind(FUN(cbind(contrasts, tl, tu)), tukey.p)
     contrast.names = if (is.null(dimnames(contrast.matrix))) 
         paste("Contrast", 1:length(contrasts)) else dimnames(contrast.matrix)[[1]]
     # drop unadjusted probs 2005 dimnames(outmat) = list(contrast.names,c('Estimate','Tukey.L','Tukey.U','Tukey.p','Unadj.p'))

--- a/src/R/estimateContrasts2.R
+++ b/src/R/estimateContrasts2.R
@@ -1,4 +1,4 @@
-estimateContrasts2 = function(contrast.matrix, fit, alpha = 0.05, row = TRUE, L) {
+estimateContrasts2 = function(contrast.matrix, fit, alpha = 0.05, row = TRUE, L, FUN) {
     if (!inherits(fit, "lm")) 
         stop("Second input is not an \"lm\" object")
     if (length(dimnames(fit$model)[[2]]) != 3) 
@@ -37,7 +37,7 @@ estimateContrasts2 = function(contrast.matrix, fit, alpha = 0.05, row = TRUE, L)
     tukey.p = 1 - round((ptukey(abs(tstat) * sqrt(2), ncol(contrast.matrix), fit$df)), 4)
     bonf.p = pmin(round(L * 2 * (1 - pt(abs(tstat), fit$df)), 4), 1)
     # drop unadjusted probs 2005 outmat = cbind(contrasts, tl, tu, tukey.p, unadj.p)
-    outmat = cbind(contrasts, tl, tu, tukey.p)
+    outmat = cbind(FUN(cbind(contrasts, tl, tu)), tukey.p)
     contrast.names = if (is.null(dimnames(contrast.matrix))) 
         paste("C", 1:length(contrasts), sep = "") else dimnames(contrast.matrix)[[1]]
     # drop unadjusted probs 2005 dimnames(outmat) = list(contrast.names,c('Estimate','Tukey.L','Tukey.U','Tukey.p','Unadj.p'))

--- a/src/R/multipleComp.R
+++ b/src/R/multipleComp.R
@@ -8,6 +8,8 @@
 #' @param fit output from the command 'lm()'.
 #' @param conf.level confidence level for the confidence interval, expressed as
 #' a percentage.
+#' @param FUN optional function to be applied to estimates and confidence intervals.
+#' Typically for backtransformation operations.
 #' @return Returns a list of estimates, confidence intervals and p-values.
 #' @keywords htest
 #' @examples
@@ -17,8 +19,15 @@
 #' fit = lm(score ~ factor(selfassess), data = computer.df)
 #' multipleComp(fit)
 #' 
+#' ## butterfat data
+#' data("butterfat.df")
+#' fit <- lm(log(Butterfat) ~ Breed, data=butterfat.df)
+#' multipleComp(fit, FUN=exp)
+#'
 #' @export multipleComp
-multipleComp = function(fit, conf.level = 0.95) {
+multipleComp = function(fit, conf.level = 0.95, FUN = identity) {
+    FUN <- match.fun(FUN)
+
     if (nrow(anova(fit)) != 2) 
         stop("This is not a 1-way ANOVA fit")
     y = fit$model[, 1]
@@ -41,6 +50,6 @@ multipleComp = function(fit, conf.level = 0.95) {
     }
     row.names(contrast.matrix) = names
     contrast.matrix = as.matrix(contrast.matrix)
-    estimateContrasts(contrast.matrix, fit, row = TRUE, alpha = 1 - conf.level)[, 1:4]
+    estimateContrasts(contrast.matrix, fit, row = TRUE, alpha = 1 - conf.level, FUN = FUN)[, 1:4]
 }
 

--- a/src/R/summary2way.R
+++ b/src/R/summary2way.R
@@ -137,6 +137,9 @@ summary2way = function(fit, page = c("table", "means", "effects", "interaction",
       names(out) = factorLabels
       print(out)
     }else{# page == "interaction")
+      if (!inter) {
+        stop("No interaction term in model")
+      }
       interactionLabel = attr(fit$terms, "term.labels")[attr(fit$terms, "order") == 2]
       out = results$comparisons[interactionLabel]
       if (all){


### PR DESCRIPTION
Changes to multipleComp, summary2way and estimateConstrasts to accept a
function `FUN` for the purposes of backtransformation, although in most
cases the functions can be wrapped with `exp()` this also transforms
p-values which can confound students and usually results in interesting
code solutions to work around the issue.

The main goal here is (without breaking existing code/examples - hence defaulting to identity) exposing a method for users/students to backtransform the inner parts of the tukey intervals without having to know matrix sub-setting, or as is more common, getting confused with p-values going erratic.