### PR TITLE
Fixes to predictGLM(), summary1way() & multipleComp()

### DIFF
--- a/src/R/estimateContrasts1.R
+++ b/src/R/estimateContrasts1.R
@@ -5,7 +5,7 @@ estimateContrasts1 = function(contrast.matrix, fit, alpha = 0.05, L, FUN) {
     
     if (length(dimnames(fit$model)[[2]]) != 2){ 
         stop("Require only one factor in \"lm\" model!")
-    }else if (!is.factor(fit$model[[2]])){ 
+    }else if (!is.factor(fit$model[[2]]) && !is.character(fit$model[[2]])){ 
         stop("Explanatory variable in \"lm\" should be a factor!")
     }
     

--- a/src/R/onewayPlot.R
+++ b/src/R/onewayPlot.R
@@ -69,8 +69,8 @@ onewayPlot.default = function(x, f, conf.level = 0.95, interval.type = "tukey", 
     
     name = c("TUKEY intervals", "HSD intervals", "LSD intervals", "Confidence intervals")[index]
     mylevels = split(y, f)
-    nfactor = as.numeric(f)
-    xmax = max(nfactor)
+    nfactor = unique(f)
+    xmax = length(nfactor)
     if (length(mylevels) < 2) 
         stop("must have at least 2 levels")
     

--- a/src/R/summary1way.R
+++ b/src/R/summary1way.R
@@ -72,12 +72,17 @@ summary1way = function(fit, digit = 5, conf.level = 0.95,
     }
     numeric.summary = cbind(size, mea, med, std, mid)
     dimnames(numeric.summary) = list(c("All Data", names(split(y, f1))), c(" Sample size", "    Mean", " Median", " Std Dev", " Midspread"))
+    
     # calculate the effects
-    dc = dummy.coef(fit)
     grandmn = mean(y)
-    grpeffs = dc[[1]] + dc[[2]] - mean(y)  #internal-constraint independent calc
+    # Small 'hack' for R 4.0+ as we may not have factors and dummy.coef
+    # doesn't handle this.
+    grpeffcol = data.frame(names(group))
+    colnames(grpeffcol) <- colnames(fit$model)[2]
+    grpeffs = predict(fit, newdata = grpeffcol) - grandmn
     effmat = c(grandmn, grpeffs)
     names(effmat) = c("typ.val", names(split(y, f1)))
+    
     if (print.out) {
         cat("ANOVA Table:\n")
         print(a.table, quote = FALSE)


### PR DESCRIPTION
Hi James, surprise PR!

Noticed that predictGLM() couldn't handle GLMs in a student-friendly way for models with terms beyond the 1st order.  I've proposed a fix here.

The change also changes the output format from a `data.frame` to a standard `matrix` (like `predict.lm()`) which will make it more student friendly - RStudio captures the `data.frame` and then separates it out from the rest of the output...  (On that note, I've also changed the `cat` to a `message` so knitr can filter.

It may be a case of needing to check this against the 20x coursebook (to avoid formatting surprises) as I know Russell added a slide or two about `predictGLM()`.

Also an additional set of commits so `summary1way()` and `multipleComp()` can work without `stringsAsFactors = TRUE`.